### PR TITLE
Add "extra" extension to Markdown renderer

### DIFF
--- a/src/corvid/__init__.py
+++ b/src/corvid/__init__.py
@@ -11,7 +11,7 @@ import jinja2
 
 
 def render_markdown(env, input_path, output_path):
-    md = markdown.Markdown()
+    md = markdown.Markdown(extensions=["extra"])
     file_parts = frontmatter.load(input_path)
 
     context = {**file_parts.metadata, "content": md.convert(file_parts.content)}


### PR DESCRIPTION
This PR adds the commonly used ["Extra"](https://python-markdown.github.io/extensions/extra/) extension for the Python-Markdown renderer. The extension includes support for:
- [Abbreviations](https://python-markdown.github.io/extensions/abbreviations/)
- [Attribute Lists](https://python-markdown.github.io/extensions/attr_list/)
- [Definition Lists](https://python-markdown.github.io/extensions/definition_lists/)
- [Fenced Code Blocks](https://python-markdown.github.io/extensions/fenced_code_blocks/)
- [Footnotes](https://python-markdown.github.io/extensions/footnotes/)
- [Tables](https://python-markdown.github.io/extensions/tables/)
- [Markdown in HTML](https://python-markdown.github.io/extensions/md_in_html/)

For what it's worth, my main motivation here is adding support for fenced code blocks, but the rest of the features seem quite useful as well, without detracting much from the intended simplicity. If the whole suite is undesirable, I'm happy to replace this PR with one that covers a smaller footprint.

And finally, thanks for making the thing I've always wanted (and actually made multiple times to varying degrees of completeness)!